### PR TITLE
Un-export dim

### DIFF
--- a/docs/src/lib/Architecture.md
+++ b/docs/src/lib/Architecture.md
@@ -30,7 +30,7 @@ The following non-standard methods are implemented:
 ```@docs
 dim_in(::AbstractNeuralNetwork)
 dim_out(::AbstractNeuralNetwork)
-ControllerFormats.dim(::AbstractNeuralNetwork)
+ControllerFormats.Architecture.dim(::AbstractNeuralNetwork)
 ```
 
 #### Implementation
@@ -50,7 +50,7 @@ The following non-standard methods are useful to implement:
 ```@docs
 dim_in(::AbstractLayerOp)
 dim_out(::AbstractLayerOp)
-ControllerFormats.dim(::AbstractLayerOp)
+ControllerFormats.Architecture.dim(::AbstractLayerOp)
 ```
 
 #### Implementation

--- a/src/Architecture/AbstractLayerOp.jl
+++ b/src/Architecture/AbstractLayerOp.jl
@@ -53,5 +53,9 @@ Return the input and output dimension of a layer operation.
 
 The pair ``(i, o)`` where ``i`` is the input dimension and ``o`` is the output
 dimension of `N`.
+
+### Notes
+
+This function is not exported due to name conflicts with other related packages.
 """
 dim(L::AbstractLayerOp) = (dim_in(L), dim_out(L))

--- a/src/Architecture/AbstractNeuralNetwork.jl
+++ b/src/Architecture/AbstractNeuralNetwork.jl
@@ -76,6 +76,10 @@ Return the input and output dimension of a neural network.
 
 The pair ``(i, o)`` where ``i`` is the input dimension and ``o`` is the output
 dimension of `N`.
+
+### Notes
+
+This function is not exported due to name conflicts with other related packages.
 """
 dim(N::AbstractNeuralNetwork) = (dim_in(N), dim_out(N))
 

--- a/src/Architecture/Architecture.jl
+++ b/src/Architecture/Architecture.jl
@@ -9,7 +9,7 @@ using Requires
 
 export AbstractNeuralNetwork, AbstractLayerOp,
        FeedforwardNetwork, DenseLayerOp,
-       layers, dim_in, dim_out, dim,
+       layers, dim_in, dim_out,
        ActivationFunction, Id, ReLU, Sigmoid, Tanh, LeakyReLU
 
 include("AbstractNeuralNetwork.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, ControllerFormats
 
-using ControllerFormats: dim
+using ControllerFormats.Architecture: dim
 
 import Flux, MAT, ONNX, YAML
 


### PR DESCRIPTION
`dim` conflicts with `LazySets` and is typically not needed from this package.