### PR TITLE
Better printing of networks

### DIFF
--- a/src/Architecture/DenseLayerOp.jl
+++ b/src/Architecture/DenseLayerOp.jl
@@ -62,6 +62,12 @@ function Base.:isapprox(L1::DenseLayerOp, L2::DenseLayerOp; atol::Real=0,
            L1.activation == L2.activation
 end
 
+function Base.show(io::IO, L::DenseLayerOp)
+    str = "$(string(DenseLayerOp)) with $(dim_in(L)) inputs, $(dim_out(L)) " *
+          "outputs, and $(L.activation) activation"
+    return print(io, str)
+end
+
 dim_in(L::DenseLayerOp) = size(L.weights, 2)
 
 dim_out(L::DenseLayerOp) = length(L.bias)

--- a/src/Architecture/FeedforwardNetwork.jl
+++ b/src/Architecture/FeedforwardNetwork.jl
@@ -55,3 +55,12 @@ function load_Flux_convert_network()
         end
     end
 end
+
+function Base.show(io::IO, N::FeedforwardNetwork)
+    str = "$(string(FeedforwardNetwork)) with $(dim_in(N)) inputs, " *
+          "$(dim_out(N)) outputs, and $(length(N)) layers:"
+    for l in layers(N)
+        str *= "\n- $l"
+    end
+    return print(io, str)
+end

--- a/test/Architecture/DenseLayerOp.jl
+++ b/test/Architecture/DenseLayerOp.jl
@@ -11,8 +11,13 @@ x = [1.0, 1]
 W = hcat([1 0.5; -0.5 0.5; -1 -0.5])
 b = [1.0, 0, -2]
 
-# output for `x` under identity activation
 L = DenseLayerOp(W, b, Id())
+
+# printing
+io = IOBuffer()
+println(io, L)
+
+# output for `x` under identity activation
 @test L(x) == W * x + b == [2.5, 0, -3.5]
 
 # invalid weight/bias combination

--- a/test/Architecture/FeedforwardNetwork.jl
+++ b/test/Architecture/FeedforwardNetwork.jl
@@ -24,6 +24,11 @@ N2 = FeedforwardNetwork([L1, L2])
 @test layers(N2) == [L1, L2]
 @test N2(x) == W2 * max.(W1 * x + b1, 0) + b2 == [-3.5, 1.25]
 
+# printing
+io = IOBuffer()
+println(io, N1)
+println(io, N2)
+
 # equality
 @test N1 == FeedforwardNetwork([L1])
 @test N1 != FeedforwardNetwork([L2])


### PR DESCRIPTION
The invalidations are expected because `show` has a default definition.