### PR TITLE
Better printing of neural networks

### DIFF
--- a/src/Architecture/ActivationFunction.jl
+++ b/src/Architecture/ActivationFunction.jl
@@ -18,6 +18,8 @@ struct Id <: ActivationFunction end
 
 (::Id)(x) = x
 
+Base.show(io::IO, ::Id) = print(io, Id)
+
 """
     ReLU
 
@@ -30,6 +32,8 @@ Rectified linear unit (ReLU) activation.
 struct ReLU <: ActivationFunction end
 
 (::ReLU)(x) = max.(x, zero(eltype(x)))
+
+Base.show(io::IO, ::ReLU) = print(io, ReLU)
 
 """
     Sigmoid
@@ -44,6 +48,8 @@ struct Sigmoid <: ActivationFunction end
 
 (::Sigmoid)(x) = @. 1 / (1 + exp(-x))
 
+Base.show(io::IO, ::Sigmoid) = print(io, Sigmoid)
+
 """
     Tanh
 
@@ -56,6 +62,8 @@ Hyperbolic tangent activation.
 struct Tanh <: ActivationFunction end
 
 (::Tanh)(x) = tanh.(x)
+
+Base.show(io::IO, ::Tanh) = print(io, Tanh)
 
 """
     LeakyReLU{N<:Number}
@@ -77,6 +85,8 @@ end
 
 (lr::LeakyReLU)(x::Number) = x >= zero(x) ? x : lr.slope * x
 (lr::LeakyReLU)(x::AbstractVector) = lr.(x)
+
+Base.show(io::IO, lr::LeakyReLU) = print(io, "$LeakyReLU($(lr.slope))")
 
 # constant instances of each activation function
 const _id = Id()

--- a/src/Architecture/DenseLayerOp.jl
+++ b/src/Architecture/DenseLayerOp.jl
@@ -64,7 +64,7 @@ function Base.:isapprox(L1::DenseLayerOp, L2::DenseLayerOp; atol::Real=0,
 end
 
 function Base.show(io::IO, L::DenseLayerOp)
-    str = "$(string(DenseLayerOp)) with $(dim_in(L)) inputs, $(dim_out(L)) " *
+    str = "$DenseLayerOp with $(dim_in(L)) inputs, $(dim_out(L)) " *
           "outputs, and $(L.activation) activation"
     return print(io, str)
 end

--- a/src/Architecture/FeedforwardNetwork.jl
+++ b/src/Architecture/FeedforwardNetwork.jl
@@ -57,7 +57,7 @@ function load_Flux_convert_network()
 end
 
 function Base.show(io::IO, N::FeedforwardNetwork)
-    str = "$(string(FeedforwardNetwork)) with $(dim_in(N)) inputs, " *
+    str = "$FeedforwardNetwork with $(dim_in(N)) inputs, " *
           "$(dim_out(N)) outputs, and $(length(N)) layers:"
     for l in layers(N)
         str *= "\n- $l"

--- a/test/Architecture/ActivationFunction.jl
+++ b/test/Architecture/ActivationFunction.jl
@@ -1,0 +1,5 @@
+# printing
+io = IOBuffer()
+for act in (Id(), ReLU(), Sigmoid(), Tanh(), LeakyReLU(0.1))
+    println(io, act)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ import Flux, MAT, ONNX, YAML
 struct TestActivation <: ActivationFunction end
 
 @testset "Architecture" begin
+    @testset "ActivationFunction" begin
+        include("Architecture/ActivationFunction.jl")
+    end
     @testset "AbstractLayerOp" begin
         include("Architecture/AbstractLayerOp.jl")
     end


### PR DESCRIPTION
This requires fewer allocations and does not print parentheses for activation functions when redundant (e.g., `Id()`).